### PR TITLE
Do not convert lists to dictionaries

### DIFF
--- a/Tests/test_bmp_reference.py
+++ b/Tests/test_bmp_reference.py
@@ -30,7 +30,7 @@ def test_bad():
 def test_questionable():
     """These shouldn't crash/dos, but it's not well defined that these
     are in spec"""
-    supported = {
+    supported = (
         "pal8os2v2.bmp",
         "rgb24prof.bmp",
         "pal1p1.bmp",
@@ -42,7 +42,7 @@ def test_questionable():
         "pal8os2sp.bmp",
         "pal8rletrns.bmp",
         "rgb32bf-xbgr.bmp",
-    }
+    )
     for f in get_files("q"):
         try:
             with Image.open(f) as im:

--- a/Tests/test_features.py
+++ b/Tests/test_features.py
@@ -72,12 +72,12 @@ def test_libimagequant_version():
 
 @pytest.mark.parametrize("feature", features.modules)
 def test_check_modules(feature):
-    assert features.check_module(feature) in {True, False}
+    assert features.check_module(feature) in (True, False)
 
 
 @pytest.mark.parametrize("feature", features.codecs)
 def test_check_codecs(feature):
-    assert features.check_codec(feature) in {True, False}
+    assert features.check_codec(feature) in (True, False)
 
 
 def test_check_warns_on_nonexistent():

--- a/Tests/test_file_libtiff.py
+++ b/Tests/test_file_libtiff.py
@@ -150,12 +150,12 @@ class TestFileLibTiff(LibTiffTestCase):
 
         # PhotometricInterpretation is set from SAVE_INFO,
         # not the original image.
-        ignored = {
+        ignored = (
             "StripByteCounts",
             "RowsPerStrip",
             "PageNumber",
             "PhotometricInterpretation",
-        }
+        )
 
         with Image.open(f) as loaded:
             if legacy_api:

--- a/Tests/test_file_tiff_metadata.py
+++ b/Tests/test_file_tiff_metadata.py
@@ -132,7 +132,7 @@ def test_write_metadata(tmp_path):
     with Image.open(f) as loaded:
         reloaded = loaded.tag_v2.named()
 
-    ignored = {"StripByteCounts", "RowsPerStrip", "PageNumber", "StripOffsets"}
+    ignored = ("StripByteCounts", "RowsPerStrip", "PageNumber", "StripOffsets")
 
     for tag, value in reloaded.items():
         if tag in ignored:


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6653

There are a few places were you converted lists to dictionaries. I imagine these were mistakes, and you meant to use tuples instead? Let me know if not.