### PR TITLE
Determining size in EpsImagePlugin

### DIFF
--- a/src/PIL/EpsImagePlugin.py
+++ b/src/PIL/EpsImagePlugin.py
@@ -213,8 +213,10 @@ class EpsImageFile(ImageFile.ImageFile):
         # go to offset - start of "%!PS"
         self.fp.seek(offset)
 
+        box = None
+
         self.mode = "RGB"
-        self._size = None
+        self._size = 1, 1  # FIXME: huh?
 
         byte_arr = bytearray(255)
         bytes_mv = memoryview(byte_arr)
@@ -333,8 +335,7 @@ class EpsImageFile(ImageFile.ImageFile):
 
         check_required_header_comments()
 
-        if not self._size:
-            self._size = 1, 1  # errors if this isn't set. why (1,1)?
+        if not box:
             msg = "cannot determine EPS bounding box"
             raise OSError(msg)
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6879

Reverts a change that seems unnecessary. I don't think `_size` is ever `None` apart from this, so it would be better not to change the type of it if we don't have to.