### PR TITLE
Removed separate test for array tobytes()

### DIFF
--- a/Tests/test_imagepath.py
+++ b/Tests/test_imagepath.py
@@ -63,17 +63,6 @@ def test_path_constructors(coords):
     assert list(p) == [(0.0, 1.0)]
 
 
-def test_path_constructor_text():
-    # Arrange
-    arr = array.array("f", (0, 1))
-
-    # Act
-    p = ImagePath.Path(arr.tobytes())
-
-    # Assert
-    assert list(p) == [(0.0, 1.0)]
-
-
 @pytest.mark.parametrize(
     "coords",
     (


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/6904

`test_path_constructor_text` seems very similar to the `test_path_constructors()` parameter `array.array("f", [0, 1]).tobytes()` at https://github.com/python-pillow/Pillow/pull/6904/files#diff-8cb5b9542dbf8d858de989b589cb235678a68783d6879592960ea426d0240bfaR54? So similar I think it isn't necessary?