### PR TITLE
Removed setters for read-only properties

### DIFF
--- a/Tests/test_file_bmp.py
+++ b/Tests/test_file_bmp.py
@@ -73,6 +73,7 @@ def test_small_palette(tmp_path):
 def test_save_too_large(tmp_path):
     outfile = str(tmp_path / "temp.bmp")
     with Image.new("RGB", (1, 1)) as im:
+        im.im = None
         im._size = (37838, 37838)
         with pytest.raises(ValueError):
             im.save(outfile)

--- a/src/PIL/GifImagePlugin.py
+++ b/src/PIL/GifImagePlugin.py
@@ -437,7 +437,7 @@ class GifImageFile(ImageFile.ImageFile):
                     self._mode = "RGBA"
                 else:
                     self._mode = "RGB"
-                self.im = self.im.convert(self.mode, Image.Dither.FLOYDSTEINBERG)
+                self.im = self.im.convert(self._mode, Image.Dither.FLOYDSTEINBERG)
             return
         if not self._prev_im:
             return

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -500,13 +500,19 @@ class Image:
 
     @property
     def size(self):
-        return self._size
+        return self.im.size if self.im else self._size
+
+    @size.setter
+    def size(self, value):
+        if self.im:
+            self.im.size = value
+        else:
+            self._size = value
 
     def _new(self, im):
         new = Image()
         new.im = im
         new.mode = im.mode
-        new._size = im.size
         if im.mode in ("P", "PA"):
             if self.palette:
                 new.palette = self.palette.copy()
@@ -694,7 +700,6 @@ class Image:
         info, mode, size, palette, data = state
         self.info = info
         self.mode = mode
-        self._size = size
         self.im = core.new(mode, size)
         if mode in ("L", "LA", "P", "PA") and palette:
             self.putpalette(palette)
@@ -2598,9 +2603,7 @@ class Image:
 
         if self.size != size:
             im = self.resize(size, resample, box=box, reducing_gap=reducing_gap)
-
             self.im = im.im
-            self._size = size
             self.mode = self.im.mode
 
         self.readonly = 0

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -482,13 +482,24 @@ class Image:
         # FIXME: take "new" parameters / other image?
         # FIXME: turn mode and size into delegating properties?
         self.im = None
-        self.mode = ""
+        self._mode = ""
         self._size = (0, 0)
         self.palette = None
         self.info = {}
         self.readonly = 0
         self.pyaccess = None
         self._exif = None
+
+    @property
+    def mode(self):
+        return self.im.mode if self.im else self._mode
+
+    @mode.setter
+    def mode(self, value):
+        if self.im:
+            self.im.mode = value
+        else:
+            self._mode = value
 
     @property
     def width(self):
@@ -512,7 +523,6 @@ class Image:
     def _new(self, im):
         new = Image()
         new.im = im
-        new.mode = im.mode
         if im.mode in ("P", "PA"):
             if self.palette:
                 new.palette = self.palette.copy()
@@ -699,7 +709,6 @@ class Image:
         Image.__init__(self)
         info, mode, size, palette, data = state
         self.info = info
-        self.mode = mode
         self.im = core.new(mode, size)
         if mode in ("L", "LA", "P", "PA") and palette:
             self.putpalette(palette)
@@ -2604,7 +2613,6 @@ class Image:
         if self.size != size:
             im = self.resize(size, resample, box=box, reducing_gap=reducing_gap)
             self.im = im.im
-            self.mode = self.im.mode
 
         self.readonly = 0
         self.pyaccess = None

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -493,13 +493,6 @@ class Image:
     def mode(self):
         return self.im.mode if self.im else self._mode
 
-    @mode.setter
-    def mode(self, value):
-        if self.im:
-            self.im.mode = value
-        else:
-            self._mode = value
-
     @property
     def width(self):
         return self.size[0]
@@ -511,13 +504,6 @@ class Image:
     @property
     def size(self):
         return self.im.size if self.im else self._size
-
-    @size.setter
-    def size(self, value):
-        if self.im:
-            self.im.size = value
-        else:
-            self._size = value
 
     @property
     def mode(self):

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -505,10 +505,6 @@ class Image:
     def size(self):
         return self.im.size if self.im else self._size
 
-    @property
-    def mode(self):
-        return self._mode
-
     def _new(self, im):
         new = Image()
         new.im = im

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -480,7 +480,6 @@ class Image:
 
     def __init__(self):
         # FIXME: take "new" parameters / other image?
-        # FIXME: turn mode and size into delegating properties?
         self.im = None
         self._mode = ""
         self._size = (0, 0)

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -507,6 +507,8 @@ class Image:
 
     def _new(self, im):
         new = Image()
+        new._mode = im.mode
+        new._size = im.size
         new.im = im
         if im.mode in ("P", "PA"):
             if self.palette:
@@ -693,6 +695,7 @@ class Image:
         Image.__init__(self)
         info, mode, size, palette, data = state
         self.info = info
+        self._mode = mode
         self.im = core.new(mode, size)
         if mode in ("L", "LA", "P", "PA") and palette:
             self.putpalette(palette)

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -139,6 +139,18 @@ class ImageFile(Image.Image):
         if self.format is not None:
             return Image.MIME.get(self.format.upper())
 
+    @property
+    def size(self):
+        if not self.tile and self.im:
+            return self.im.size
+        return self._size
+
+    @property
+    def mode(self):
+        if not self.tile and self.im:
+            return self.im.mode
+        return self._mode
+
     def __setstate__(self, state):
         self.tile = []
         super().__setstate__(state)


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7271, to fix the failing tests.

I've removed the setters for `mode` and `size`, restored some of the lines you removed, removed a duplicate `@property` and updated a BMP test and GifImagePlugin.

You have considered that the image might not be loaded yet, meaning that there is no `self.im`. I think you also need to consider seeking to another frame, but before, at which time that there will be a `self.im` but the size of the image should be the size of the tile that isn't loaded yet. As a result, I've also added a `@property` in ImageFile for `size`. I've also added one for `mode`.

With these changes, all tests now pass.