### PR TITLE
Test unsupported autocontrast mode

### DIFF
--- a/Tests/test_imageops.py
+++ b/Tests/test_imageops.py
@@ -433,6 +433,12 @@ def test_exif_transpose_in_place():
         assert_image_equal(im, expected)
 
 
+def test_autocontrast_unsupported_mode():
+    im = Image.new("RGBA", (1, 1))
+    with pytest.raises(OSError):
+        ImageOps.autocontrast(im)
+
+
 def test_autocontrast_cutoff():
     # Test the cutoff argument of autocontrast
     with Image.open("Tests/images/bw_gradient.png") as img:


### PR DESCRIPTION
Suggestion for a test to add to https://github.com/python-pillow/Pillow/pull/7490

This doesn't fail without your change, it simply improves coverage so that codecov/patch will stop saying that 0% of the diff is hit.