### PR TITLE
Moved code onto single line

### DIFF
--- a/src/_imagingcms.c
+++ b/src/_imagingcms.c
@@ -181,8 +181,7 @@ cms_profile_dealloc(CmsProfileObject *self) {
 /* a transform represents the mapping between two profiles */
 
 typedef struct {
-    PyObject_HEAD
-    cmsHTRANSFORM transform;
+    PyObject_HEAD cmsHTRANSFORM transform;
 } CmsTransformObject;
 
 static PyTypeObject CmsTransform_Type;


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7931, to be consistent with other parts of the code.

```
$ grep -r "PyObject_HEAD" .      
./display.c:    PyObject_HEAD ImagingDIB dib;
./_imagingft.c:    PyObject_HEAD FT_Face face;
./_webp.c:    PyObject_HEAD WebPAnimEncoder *enc;
./_webp.c:    PyObject_HEAD WebPAnimDecoder *dec;
./decode.c:    PyObject_HEAD int (*decode)(
./encode.c:    PyObject_HEAD int (*encode)(
./path.c:    PyObject_HEAD Py_ssize_t count;
./outline.c:    PyObject_HEAD ImagingOutline outline;
./_imaging.c:    PyObject_HEAD Imaging image;
./_imaging.c:    PyObject_HEAD ImagingObject *ref;
./_imaging.c:    PyObject_HEAD ImagingObject *image;
./_imaging.c:    PyObject_HEAD ImagingObject *image;
./_imagingcms.c:    PyObject_HEAD cmsHPROFILE profile;
./_imagingcms.c:    PyObject_HEAD char mode_in[8];
```