### PR TITLE
Use hopper

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -28,7 +28,7 @@ elif "GITHUB_ACTIONS" in os.environ:
     uploader = "github_actions"
 
 
-image_mode_names = (
+modes = (
     "1",
     "L",
     "LA",

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1036,14 +1036,7 @@ class TestImageBytes:
 
     @pytest.mark.parametrize("mode", image_mode_names)
     def test_getdata_putdata(self, mode: str) -> None:
-        # create an image with 1 pixel to get its pixel size
-        im = Image.new(mode, (1, 1))
-        pixel_size = len(im.tobytes())
-
-        # create a new image with incrementing byte values
-        im = Image.new(mode, (2, 2))
-        source_bytes = bytes(range(im.width * im.height * pixel_size))
-        im.frombytes(source_bytes)
+        im = hopper(mode)
 
         # copy the data from the previous image to a new image
         # and check that they are the same

--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -28,15 +28,15 @@ from .helper import (
     assert_image_similar_tofile,
     assert_not_all_same,
     hopper,
-    image_mode_names,
     is_win32,
     mark_if_feature_version,
+    modes,
     skip_unless_feature,
 )
 
 
 class TestImage:
-    @pytest.mark.parametrize("mode", image_mode_names)
+    @pytest.mark.parametrize("mode", modes)
     def test_image_modes_success(self, mode: str) -> None:
         Image.new(mode, (1, 1))
 
@@ -1017,7 +1017,7 @@ class TestImage:
 
 
 class TestImageBytes:
-    @pytest.mark.parametrize("mode", image_mode_names)
+    @pytest.mark.parametrize("mode", modes)
     def test_roundtrip_bytes_constructor(self, mode: str) -> None:
         im = hopper(mode)
         source_bytes = im.tobytes()
@@ -1025,7 +1025,7 @@ class TestImageBytes:
         reloaded = Image.frombytes(mode, im.size, source_bytes)
         assert reloaded.tobytes() == source_bytes
 
-    @pytest.mark.parametrize("mode", image_mode_names)
+    @pytest.mark.parametrize("mode", modes)
     def test_roundtrip_bytes_method(self, mode: str) -> None:
         im = hopper(mode)
         source_bytes = im.tobytes()
@@ -1034,7 +1034,7 @@ class TestImageBytes:
         reloaded.frombytes(source_bytes)
         assert reloaded.tobytes() == source_bytes
 
-    @pytest.mark.parametrize("mode", image_mode_names)
+    @pytest.mark.parametrize("mode", modes)
     def test_getdata_putdata(self, mode: str) -> None:
         im = hopper(mode)
 

--- a/Tests/test_image_access.py
+++ b/Tests/test_image_access.py
@@ -10,7 +10,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import assert_image_equal, hopper, image_mode_names, is_win32
+from .helper import assert_image_equal, hopper, is_win32, modes
 
 # CFFI imports pycparser which doesn't support PYTHONOPTIMIZE=2
 # https://github.com/eliben/pycparser/pull/198#issuecomment-317001670
@@ -205,7 +205,7 @@ class TestImageGetPixel(AccessTest):
         with pytest.raises(error):
             im.getpixel((-1, -1))
 
-    @pytest.mark.parametrize("mode", image_mode_names)
+    @pytest.mark.parametrize("mode", modes)
     def test_basic(self, mode: str) -> None:
         self.check(mode)
 


### PR DESCRIPTION
Ideas for https://github.com/python-pillow/Pillow/pull/7921

- Rather than determining pixel size to create a simple image, you can just use `hopper()`
- Shorten `image_mode_names` to `modes`