### PR TITLE
BGR;16 does not fail on big-endian

### DIFF
--- a/Tests/test_image.py
+++ b/Tests/test_image.py
@@ -1037,8 +1037,8 @@ class TestImageBytes:
 
     @pytest.mark.parametrize("mode", modes)
     def test_getdata_putdata(self, mode: str) -> None:
-        if is_big_endian and mode in ("BGR;15", "BGR;16"):
-            pytest.xfail(f"Known failure of {mode} on big-endian")
+        if is_big_endian and mode == "BGR;15":
+            pytest.xfail("Known failure of BGR;15 on big-endian")
         im = hopper(mode)
         reloaded = Image.new(mode, im.size)
         reloaded.putdata(im.getdata())


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/7921

Testing, I found that BGR;16 doesn't actually fail.